### PR TITLE
Fix GitHub Actions: Add build environment to site workflow

### DIFF
--- a/.github/workflows/site-build-and-push.yml
+++ b/.github/workflows/site-build-and-push.yml
@@ -20,6 +20,7 @@ env:
 
 jobs:
   build-and-push:
+    environment: build
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Fix site workflow to use 'build' environment for accessing QUAY credentials. This resolves the 'Username and password required' errors in the GitHub Actions workflows.